### PR TITLE
Add HR info to sleep data

### DIFF
--- a/sleep.go
+++ b/sleep.go
@@ -14,6 +14,8 @@ type Sleep struct {
 	LightSleepDuration int       `json:"light_sleep_duration,omitempty"`
 	DeepSleepDuration  int       `json:"deep_sleep_duration,omitempty"`
 	AwakeDuration      int       `json:"awake_duration,omitempty"`
+	HrAverage          int       `json:"hr_average,omitempty"`
+	HrLowest           int       `json:"hr_lowest,omitempty"`
 	Quality            int       `json:"quality,omitempty"`
 }
 

--- a/sleep_test.go
+++ b/sleep_test.go
@@ -24,6 +24,8 @@ var sleepTestCases = []struct {
 			LightSleepDuration: 70,
 			DeepSleepDuration:  70,
 			AwakeDuration:      70,
+			HrAverage:          89,
+			HrLowest:           60,
 			Quality:            8,
 		},
 		status: http.StatusCreated,


### PR DESCRIPTION
The Sleep endpoint has been extended to include the ability to set the average and lowest heart rates. This PR adds support for these new fields.